### PR TITLE
Add keyboard shortcuts to popups

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -39,6 +39,12 @@ export default class extends Elem {
           this.delete()
           if (this[e.target.id]) this[e.target.id]()
         })
+        this.addEvent("keyup", e => {
+          if (["Escape", "Enter"].includes(e.key)) {
+            this.delete()
+            if (e.key === "Enter") // TODO: Trigger a click on the submit button/method here
+          }
+        })
         break
       default:
         this.addEvent("click", e => {

--- a/src/popup.js
+++ b/src/popup.js
@@ -42,7 +42,10 @@ export default class extends Elem {
         this.addEvent("keyup", e => {
           if (["Escape", "Enter"].includes(e.key)) {
             this.delete()
-            if (e.key === "Enter") // TODO: Trigger a click on the submit button/method here
+            if (e.key === "Enter") {
+              const confirmBtn = e.target.closest(`${mConsts.klass.content}`).getElementById(`${mConsts.ids.confirmOk}`)
+              confirmBtn.click()
+            }
           }
         })
         break


### PR DESCRIPTION
Backstory: We'd love to see `Enter` and `Escape` keyboard shortcuts for the modals/popups displayed by `awn`.
Users often expect to use Esc/Enter keys to interact with modals and atm the focus stays on the trigger element (e.g. click Run Example in [this official example](https://f3oall.github.io/awesome-notifications/docs/popups/confirmation-window)) and when I press `Enter` after triggering the popup, another popup is displayed on top (further darkening the background). This can go on forever - imagine a confused user spamming away at their Enter/Escape keys.

TODO: I wasn't sure of the correct way to call the confirm event, so please see the `TODO` item on line `#45` and help me out a bit 🙏 

Overall we really love using this library and we'd appreciate this feature immensely! 