### PR TITLE
Remove comma between popup buttons

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -24,7 +24,7 @@ export default class extends Elem {
         if (this[mConsts.ids.confirmCancel] !== false) {
           buttons.push(`<button class='${mConsts.klass.button} ${mConsts.klass.cancelBtn}'id='${mConsts.ids.confirmCancel}'>${this.options.labels.confirmCancel}</button>`)
         }
-        innerHTML = `${this.options.icon(this.type)}<div class='${mConsts.klass.title}'>${this.options.label(this.type)}</div><div class="${mConsts.klass.content}">${innerHTML}</div><div class='${mConsts.klass.buttons} ${mConsts.klass.buttons}-${buttons.length}'>${buttons.join()}</div>`
+        innerHTML = `${this.options.icon(this.type)}<div class='${mConsts.klass.title}'>${this.options.label(this.type)}</div><div class="${mConsts.klass.content}">${innerHTML}</div><div class='${mConsts.klass.buttons} ${mConsts.klass.buttons}-${buttons.length}'>${buttons.join('')}</div>`
         break
       case "async-block":
         innerHTML = `${innerHTML}<div class="${mConsts.klass.dotAnimation}"></div>`


### PR DESCRIPTION
This PR closes #26

Calling `.join()` without a separator symbol defaults it to a comma `,`.
I'm not sure if it's better to call `.join('')` or `.join(' ')`, but let me know so I can modify the PR
