### PR TITLE
HLS add percent

### DIFF
--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -3,9 +3,9 @@ $awn-container-z-index: 99998 !default;
 $awn-container-padding: 24px !default;
 
 // Colors
-$awn-primary-color: hsl(0, 0, 50%) !default;
-$awn-primary-background: hsl(0, 0, 92%) !default;
-$awn-primary-border-color: hsl(0, 0, 82%) !default;
+$awn-primary-color: hsl(0, 0%, 50%) !default;
+$awn-primary-background: hsl(0, 0%, 92%) !default;
+$awn-primary-border-color: hsl(0, 0%, 82%) !default;
 
 $awn-success-color: hsl(100, 65%, 32%) !default;
 $awn-success-background: hsl(100, 74%, 90%) !default;


### PR DESCRIPTION
Webpack 5 throws a warning 

`DEPRECATION WARNING: $saturation: Passing a number without unit % (0) is deprecated.`
